### PR TITLE
Use github pages link for divviup-ts

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -22,7 +22,7 @@ const sidebars = {
             {
               type: 'link',
               label: 'divviup-ts (TypeScript)',
-              href: 'https://docs.divviup.org/divviup-ts',
+              href: 'https://divviup.github.io/divviup-ts',
             },
             {
               type: 'link',


### PR DESCRIPTION
I thought I could make this a subpath of docs.divviup.org, but that's not how GitHub Pages custom domains works. Just use the GitHub pages link.

We _could_ make it `divviup-ts.docs.divviup.org`, but I don't think that's really better.