### PR TITLE
Add workflow for dependabot automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,13 @@
+name: Dependabot auto-merge
+on: pull_request
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Approve & enable auto-merge for Dependabot PRs
+        run: gh pr review --approve -b "Auto-approving dependabot PR." "$PR_URL" && gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.DIVVIUP_GITHUB_AUTOMATION_DEPENDABOT_APPROVER_PAT}}


### PR DESCRIPTION
This has similar risks as to enabling automerge on divviup-api, namely there's
much validation that the UI looks/works the way we expect.

However, I think the risk is much lower since we just use markdown and don't have any
custom React components. The site is also not mission-critical (at least at the moment)
so IMO it's acceptable for there to be some churn if a bad update is merged.
