### PR TITLE
ci: Remove autoformatting job

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,10 +1,5 @@
 name: Format and Test
 
-# Prevent formatting commit collisions when pushing code too fast.
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 on:
   pull_request:
     branches:
@@ -14,55 +9,20 @@ jobs:
   format:
     name: Format code
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      head: ${{ steps.head.outputs.head }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Check out the branch that the PR refers to, so the git HEAD isn't detached.
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: yarn
-      - run: npx prettier --write .
-      - name: Check if code is unformatted
-        if: github.event.pull_request.head.repo.fork
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "Code is not formatted properly. Please format code using 'npx prettier --write .'"
-            exit 1
-          fi
-      - name: Push changes
-        if: "!github.event.pull_request.head.repo.fork"
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            # github-actions name and email derived from https://github.com/orgs/community/discussions/26560
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git config user.name "github-actions[bot]"
-            git commit -am "Automatic formatting"
-            git push
-          fi
-      - name: Get head SHA
-        id: head
-        run: echo "head=$(git rev-parse HEAD)" >>"$GITHUB_OUTPUT"
+
+      - run: npx prettier --check .
 
   test:
     name: Test deployment
     runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    needs: [format]
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Check out the HEAD from the previous workflow, to catch any mistakes that the formatter
-          # may have introduced.
-          ref: "${{ needs.format.outputs.head }}"
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - uses: actions/setup-node@v4
         with:
           node-version: 18
@@ -72,24 +32,3 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Test build website
         run: yarn build
-
-      # The format job may have changed the PR's head. When the head is changed through a workflow
-      # another workflow is not kicked off to prevent infinite loops. Thus, the new head never
-      # receives its workflow status.
-      #
-      # Workaround this by setting a status check to the new head manually.
-      #
-      # This does not work for forked repositories.
-      - name: Set status check
-        if: always() && !github.event.pull_request.head.repo.fork
-        env:
-          GH_TOKEN: ${{ github.token }}      
-        run: |
-          gh api \
-            repos/${{ github.repository }}/commits/${{ needs.format.outputs.head }}/statuses \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            -f state="${{ job.status }}" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            -f context="Format and Test"

--- a/docs/command-line-tutorial.md
+++ b/docs/command-line-tutorial.md
@@ -212,10 +212,9 @@ Saved new collector credential to /your/current/directory/collector-credential-1
 
 :::warning
 
-This credential isn't sensitive because it's only useful in your local
-instance of Divvi Up. But collector credentials generated against the production
-service should be carefully managed. Consider using a password manager to
-protect them.
+This credential isn't sensitive because it's only useful in your local instance
+of Divvi Up. But collector credentials generated against the production service
+should be carefully managed. Consider using a password manager to protect them.
 
 :::
 


### PR DESCRIPTION
This job is fairly problematic.

- It cannot autoformat forks, at all.
- Even to coexist with forks, e.g. by just checking forked PRs, subtly breaks normal PRs
  - The custom status check, necessary for appropriately checking the formatted commit, doesn't work with forks because it doesn't fit in GitHub Action's permissions model.
  - We can turn off the required status check, but then dependabot will YOLO merge dependencies because there's nothing stopping it.

With more hacks we can probably fix these problems, but I don't think we should spend too much time on it. I also broadly think that CI jobs that attempt to modify PRs aren't such a great area. Instead we're better off with precommit hooks, autoformatting in IDE, etc.