### PR TITLE
docs: try to consistently use telemetry term

### DIFF
--- a/docs/command-line-tutorial.md
+++ b/docs/command-line-tutorial.md
@@ -192,7 +192,7 @@ export HELPER_ID=96301951-c848-4a57-b4f5-32812e4db1be
 ## Collector Credential
 
 Next, generate a collector-credential for the task. The collector credential
-will be used by the collector to export the aggregated statistics.
+will be used by the collector to export the aggregated telemetry.
 
 ```sh
 divviup collector-credential generate --save

--- a/docs/command-line-video-demo.md
+++ b/docs/command-line-video-demo.md
@@ -9,4 +9,4 @@ The video below shows the [command line tutorial](./command-line-tutorial) with
 some additional explanation. If you prefer to try it for yourself on your
 computer checkout the [command line tutorial](./command-line-tutorial).
 
-<iframe width="840" height="473" src="https://www.youtube.com/embed/sCJlJAy1Fyg?si=MUUburZe1XbOjvq2" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="840" height="473" src="https://www.youtube.com/embed/QC5rH4FO6fw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -8,9 +8,10 @@ Learn how Divvi Up works and how it protects privacy.
 
 ## Breakdown
 
-Divvi Up ingests measurements and aggregates them, while protecting the privacy
-of each individual measurement. This can be broadly broken down into several
-steps, described in the following sections.
+Divvi Up ingests and aggregates telemetric data while protecting the privacy of
+each individual measurement. Example use cases might be application metrics,
+survey results, or machine learning data. The process can be broadly broken down
+into several steps, described in the following sections.
 
 <!-- TODO(inahga): Consider making this a more detailed `mermaid` diagram -->
 
@@ -47,9 +48,9 @@ For each measurement, the subsequent steps are performed.
 
 ### Step 2: Client shards the measurement
 
-The app uses the DAP client library to randomly shard the measurement into two
-parts, known as report shares. One report share is for the leader aggregator,
-and the other for the helper aggregator.
+The app uses the DAP client library to randomly shard the telemetric data,
+called a measurement, into two parts, known as report shares. One report share
+is for the leader aggregator, and the other for the helper aggregator.
 
 The client library encrypts each share with a public key advertised by the
 respective aggregator.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -5,10 +5,10 @@ sidebar_position: 1
 
 # Overview
 
-Divvi Up is a privacy preserving metrics platform for collecting aggregate
-statistics. Using Divvi Up can help users gain insights into a user base while
-respecting users' individual privacy, eliminating the need to store PII for
-telemetry, and mitigating compliance risks.
+Divvi Up is a privacy preserving telemetry service. It enables application
+owners to gain insights into a user base while respecting users' individual
+privacy, eliminating the need to store PII for telemetry, and mitigating
+compliance risks.
 
 The best two places to get started are:
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,7 @@ const darkTheme = themes.dracula;
 const config = {
   title: "Divvi Up",
   tagline:
-    "Documentation site for Divvi Up, a privacy-respecting system for aggregate statistics.",
+    "Documentation site for Divvi Up, a privacy-respecting telemetry service for metrics or machine learning.",
   favicon: "favicon.png",
 
   // Set the production url of your site here


### PR DESCRIPTION
Try and be consistent around the language of Divvi Up being a "privacy preserving telemtry service". This gets a little tricky in the how it works section because the DAP protocol talks about "measurements" but I think it is easy enough to say a measurement is the telemetric data.