### PR TITLE
docs: fix typo in command line video

### DIFF
--- a/docs/command-line-video-demo.md
+++ b/docs/command-line-video-demo.md
@@ -9,4 +9,4 @@ The video below shows the [command line tutorial](./command-line-tutorial) with
 some additional explanation. If you prefer to try it for yourself on your
 computer checkout the [command line tutorial](./command-line-tutorial).
 
-<iframe width="840" height="473" src="https://www.youtube.com/embed/QC5rH4FO6fw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<iframe width="840" height="473" src="https://www.youtube.com/embed/z54EnRiSrtI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>


### PR DESCRIPTION
I misspelled divviup on the very first slide. Fix :(
<img width="553" alt="Screenshot 2024-07-31 at 11 57 26 AM" src="https://github.com/user-attachments/assets/cdf387d5-6e6c-40e7-9877-ae3b6c4592c0">
