### PR TITLE
Add a documentation field for slug #aggregation-job-abandoned

### DIFF
--- a/docs/references/janus-errors.md
+++ b/docs/references/janus-errors.md
@@ -28,8 +28,8 @@ and troubleshooting techniques follows.
 ### Aggregation Job Abandoned
 
 This error occurs if a Janus leader receives a request to act on an aggregation
-job that has been abandoned. Such jobs are no longer being processed, and can
-no longer be collected for.
+job that has been abandoned. Such jobs are no longer being processed, and can no
+longer be collected for.
 
 The [DAP specification][agg-job-deletion] states that if a leader must abandon
 an aggregation job, it should delete that resource in the helper to let it clean

--- a/docs/references/janus-errors.md
+++ b/docs/references/janus-errors.md
@@ -27,15 +27,9 @@ and troubleshooting techniques follows.
 
 ### Aggregation Job Abandoned
 
-This error occurs if a Janus leader receives a request to act on an aggregation
-job that has been abandoned. Such jobs are no longer being processed, and can no
-longer be collected for.
-
-The [DAP specification][agg-job-deletion] states that if a leader must abandon
-an aggregation job, it should delete that resource in the helper to let it clean
-up its resources. The Janus leader does this, and the Janus helper supports
-`DELETE` requests on an aggregation job URI. Deleted aggregation jobs may not be
-acted upon further and any further attempts to run that job will fail.
+This error occurs if a Janus helper receives a request to act on an aggregation
+job that has been abandoned. Such jobs can no longer be processed. Aggregation
+jobs may be abandoned due to internal errors.
 
 ### Aggregation Job Deleted
 

--- a/docs/references/janus-errors.md
+++ b/docs/references/janus-errors.md
@@ -25,6 +25,18 @@ The `type` field defines a URN that is defined in the [DAP specification][1].
 Some errors that Janus encounter are not defined in DAP. A list of these errors
 and troubleshooting techniques follows.
 
+### Aggregation Job Abandoned
+
+This error occurs if a Janus leader receives a request to act on an aggregation
+job that has been abandoned. Such jobs are no longer being processed, and can
+no longer be collected for.
+
+The [DAP specification][agg-job-deletion] states that if a leader must abandon
+an aggregation job, it should delete that resource in the helper to let it clean
+up its resources. The Janus leader does this, and the Janus helper supports
+`DELETE` requests on an aggregation job URI. Deleted aggregation jobs may not be
+acted upon further and any further attempts to run that job will fail.
+
 ### Aggregation Job Deleted
 
 This error occurs if a Janus helper receives a request to initialize or continue


### PR DESCRIPTION
This comes from https://github.com/divviup/janus/pull/3630 and intends to fix #127.

I'm not entirely confident about the leader/aggregator part, but I figure you, kind reviewer, can set me straight.